### PR TITLE
Replace the direct pip install htcondor with a virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ import htcondor
 > If you need to install the python bindings, in your system shell, run
 >
 > ```
-> python3 -m pip install htcondor
+> python3 -m venv virtualenv
+> source virtualenv/bin/activate
+> pip install htcondor
 > ```
 
 To demonstrate that the bindings are loaded, run this command:


### PR DESCRIPTION
The recommended way to install additional packages for python3 is by using virtual environments. E.g. on Debian systems using pip outside of a virtual environment is actively discouraged.